### PR TITLE
Use closure to make creating new menu event easier

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,19 +44,33 @@ function App() {
     if (!logseq.settings) {
       return
     }
+
+logseq.Editor.getPageBlocksTree("ollama-logseq-config").then((blocks) => {
+  blocks!.forEach((block) => {
+    logseq.Editor.getBlockProperty(block.uuid, "ollama-context-menu-title").then((title) => {
+      logseq.Editor.getBlockProperty(block.uuid, "ollama-prompt-prefix").then((prompt_prefix) => {
+        logseq.Editor.registerBlockContextMenuItem(title, promptFromBlockEventClosure(prompt_prefix))
+      })
+    }).catch((reason) => {
+    })
+  })
+}).catch((reason) => {
+  console.log("Can not find the configuration page named 'ollama-logseq-config'")
+  console.log(reason)
+})
+    
+
     logseq.Editor.registerSlashCommand("ollama", ollamaUI)
     logseq.Editor.registerBlockContextMenuItem("Ollama: Create a flash card", convertToFlashCardFromEvent)
     logseq.Editor.registerBlockContextMenuItem("Ollama: Divide into subtasks", DivideTaskIntoSubTasksFromEvent)
     logseq.Editor.registerBlockContextMenuItem("Ollama: Prompt from Block", promptFromBlockEventClosure())
     logseq.Editor.registerBlockContextMenuItem("Ollama: Summarize block", promptFromBlockEventClosure("Summarize: "))
-    logseq.Editor.registerBlockContextMenuItem("Ollama: 总结 Block", promptFromBlockEventClosure("总结: "))
     logseq.Editor.registerBlockContextMenuItem("Ollama: Expand Block", promptFromBlockEventClosure("Expand: "))
-    logseq.Editor.registerBlockContextMenuItem("Ollama: 扩展 Block", promptFromBlockEventClosure("扩展: "))
 
     logseq.App.registerCommandShortcut(
       { "binding": logseq.settings.shortcut },
       ollamaUI
-    );
+    ); 
   }, [])
 
   if (visible) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,9 +4,7 @@ import {
   convertToFlashCardFromEvent,
   DivideTaskIntoSubTasksFromEvent,
   ollamaUI,
-  summarizeBlockFromEvent,
-  promptFromBlockEvent,
-  expandBlockEvent
+  promptFromBlockEventClosure
 } from "./ollama";
 import { useAppVisible } from "./utils";
 
@@ -48,10 +46,13 @@ function App() {
     }
     logseq.Editor.registerSlashCommand("ollama", ollamaUI)
     logseq.Editor.registerBlockContextMenuItem("Ollama: Create a flash card", convertToFlashCardFromEvent)
-    logseq.Editor.registerBlockContextMenuItem("Ollama: Summarize block", summarizeBlockFromEvent)
     logseq.Editor.registerBlockContextMenuItem("Ollama: Divide into subtasks", DivideTaskIntoSubTasksFromEvent)
-    logseq.Editor.registerBlockContextMenuItem("Ollama: Prompt from Block", promptFromBlockEvent)
-    logseq.Editor.registerBlockContextMenuItem("Ollama: Expand Block", expandBlockEvent)
+    logseq.Editor.registerBlockContextMenuItem("Ollama: Prompt from Block", promptFromBlockEventClosure())
+    logseq.Editor.registerBlockContextMenuItem("Ollama: Summarize block", promptFromBlockEventClosure("Summarize: "))
+    logseq.Editor.registerBlockContextMenuItem("Ollama: 总结 Block", promptFromBlockEventClosure("总结: "))
+    logseq.Editor.registerBlockContextMenuItem("Ollama: Expand Block", promptFromBlockEventClosure("Expand: "))
+    logseq.Editor.registerBlockContextMenuItem("Ollama: 扩展 Block", promptFromBlockEventClosure("扩展: "))
+
     logseq.App.registerCommandShortcut(
       { "binding": logseq.settings.shortcut },
       ollamaUI

--- a/src/ollama.tsx
+++ b/src/ollama.tsx
@@ -101,10 +101,8 @@ async function ollamaGenerate(prompt: string, parameters?: OllamaGenerateParamet
       throw new Error("Error in Ollama request: " + response.statusText)
     }
     const data = await response.json()
-
-    console.log(data)
     
-    return data.response
+    return data
   } catch (e: any) {
     console.log(e)
     logseq.UI.showMsg("Error in Ollama request")
@@ -212,9 +210,14 @@ export async function promptFromBlockEvent(b: IHookEvent) {
     const answerBlock = await logseq.Editor.insertBlock(currentBlock!.uuid, '🦙Generating ...', { before: false })
     const params = await getOllamaParametersFromBlockProperties(currentBlock!)
     const prompt = currentBlock!.content.replace(/^.*::.*$/gm, '') // nasty hack to remove properties from block content
-    const response = await ollamaGenerate(prompt, params);
+    const result = await ollamaGenerate(prompt, params);
     
-    await logseq.Editor.updateBlock(answerBlock!.uuid, `${response}`)
+    console.log(result)
+
+    if (params.usecontext) {
+      await logseq.Editor.upsertBlockProperty(currentBlock!.uuid, 'ollama-generate-context', result.context)
+    }
+    await logseq.Editor.updateBlock(answerBlock!.uuid, `${result.response}`)
   } catch (e: any) {
     logseq.UI.showMsg(e.toString(), 'warning')
     console.error(e)


### PR DESCRIPTION
I turn the prompt from the block function into a creator of closure so the new menu functions can easily have different prefixes to the prompt. Take a look at the App.tsx. I am trying to figure out how to make this use configurable so users can create different functions to fit their working styles. I use English and Chinese in my work and summarize and expand them using different prompts. 

```
    logseq.Editor.registerBlockContextMenuItem("Ollama: Prompt from Block", promptFromBlockEventClosure())
    logseq.Editor.registerBlockContextMenuItem("Ollama: Summarize block", promptFromBlockEventClosure("Summarize: "))
    logseq.Editor.registerBlockContextMenuItem("Ollama: 总结 Block", promptFromBlockEventClosure("总结: "))
    logseq.Editor.registerBlockContextMenuItem("Ollama: Expand Block", promptFromBlockEventClosure("Expand: "))
    logseq.Editor.registerBlockContextMenuItem("Ollama: 扩展 Block", promptFromBlockEventClosure("扩展: "))
```

