### PR TITLE
feat: Add custom prompt defined in configuration to apply on block

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,4 @@ lerna-debug.log
 # System Files
 .DS_Store
 Thumbs.db
+package-lock.json

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,7 +15,6 @@ const options = [
   'Divide into subtasks',
   'Summarize',
   'Summarize Block',
-  'Custom prompt on block',
   'Convert to flash card',
 ];
 
@@ -64,6 +63,7 @@ function App() {
     logseq.Editor.registerBlockContextMenuItem("Ollama: Create a flash card", convertToFlashCardFromEvent)
     logseq.Editor.registerBlockContextMenuItem("Ollama: Divide into subtasks", DivideTaskIntoSubTasksFromEvent)
     logseq.Editor.registerBlockContextMenuItem("Ollama: Prompt from Block", promptFromBlockEventClosure())
+    logseq.Editor.registerBlockContextMenuItem("Ollama: Custom prompt on Block", promptFromBlockEventClosure(logseq.settings.custom_prompt_block))
     logseq.Editor.registerBlockContextMenuItem("Ollama: Summarize block", promptFromBlockEventClosure("Summarize: "))
     logseq.Editor.registerBlockContextMenuItem("Ollama: Expand Block", promptFromBlockEventClosure("Expand: "))
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ const options = [
   'Divide into subtasks',
   'Summarize',
   'Summarize Block',
+  'Custom prompt on block',
   'Convert to flash card',
 ];
 

--- a/src/components/OllamaCommandPallete.tsx
+++ b/src/components/OllamaCommandPallete.tsx
@@ -6,7 +6,7 @@ import {
   CommandItem,
   CommandList,
 } from "@/components/ui/command"
-import { convertToFlashCardCurrentBlock, DivideTaskIntoSubTasksCurrentBlock, summarize, summarizeBlock } from "@/ollama";
+import { convertToFlashCardCurrentBlock, DivideTaskIntoSubTasksCurrentBlock, summarize, summarizeBlock, customPromptBlock } from "@/ollama";
 import { PromptAI } from "./PromptAI";
 
 export function OllamaCommandPallete({ options, theme }: { options: string[], theme: string }) {
@@ -27,6 +27,10 @@ export function OllamaCommandPallete({ options, theme }: { options: string[], th
       case "summarize block":
         logseq.hideMainUI()
         summarizeBlock()
+        break;
+      case "custom prompt on block":
+        logseq.hideMainUI()
+        customPromptBlock()
         break;
       case "convert to flash card":
         logseq.hideMainUI()

--- a/src/components/OllamaCommandPallete.tsx
+++ b/src/components/OllamaCommandPallete.tsx
@@ -6,7 +6,7 @@ import {
   CommandItem,
   CommandList,
 } from "@/components/ui/command"
-import { convertToFlashCardCurrentBlock, DivideTaskIntoSubTasksCurrentBlock, summarize, summarizeBlock, customPromptBlock } from "@/ollama";
+import { convertToFlashCardCurrentBlock, DivideTaskIntoSubTasksCurrentBlock, summarize, summarizeBlock } from "@/ollama";
 import { PromptAI } from "./PromptAI";
 
 export function OllamaCommandPallete({ options, theme }: { options: string[], theme: string }) {
@@ -27,10 +27,6 @@ export function OllamaCommandPallete({ options, theme }: { options: string[], th
       case "summarize block":
         logseq.hideMainUI()
         summarizeBlock()
-        break;
-      case "custom prompt on block":
-        logseq.hideMainUI()
-        customPromptBlock()
         break;
       case "convert to flash card":
         logseq.hideMainUI()

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -36,13 +36,6 @@ let settings: SettingSchemaDesc[] = [
     description: "Shortcut to open plugin command pallete",
     default: "mod+shift+o"
   },
-  {
-    key: "custom_prompt_block",
-    type: "string",
-    title: "Custom prompt block",
-    description: "Define your custom prompt and use a block as context",
-    default: "Translate in French : "
-  },
 ]
 
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -36,6 +36,13 @@ let settings: SettingSchemaDesc[] = [
     description: "Shortcut to open plugin command pallete",
     default: "mod+shift+o"
   },
+  {
+    key: "custom_prompt_block",
+    type: "string",
+    title: "Custom prompt block",
+    description: "Define your custom prompt and use a block as context",
+    default: "Translate in French : "
+  },
 ]
 
 

--- a/src/ollama.tsx
+++ b/src/ollama.tsx
@@ -178,12 +178,32 @@ export async function summarizeBlock() {
     const currentBlock = await logseq.Editor.getCurrentBlock()
     let summaryBlock = await logseq.Editor.insertBlock(currentBlock!.uuid, `⌛Summarizing Block...`, { before: false })
     const summary = await promptLLM(`Summarize the following ${currentBlock!.content}`);
+
     await logseq.Editor.updateBlock(summaryBlock!.uuid, `Summary: ${summary}`)
   } catch (e: any) {
     logseq.App.showMsg(e.toString(), 'warning')
     console.error(e)
   }
 }
+
+export async function customPromptBlock() {
+  try {
+    if (!logseq.settings) {
+      throw new Error("Couldn't find ollama-logseq settings")
+    }
+  
+    // TODO: Get contnet of current block and subblocks
+    const currentBlock = await logseq.Editor.getCurrentBlock()
+    let customPromptBlock = await logseq.Editor.insertBlock(currentBlock!.uuid, `⌛Apply custom prompt...`, { before: false })
+    const customPrompt = await promptLLM(`${logseq.settings.custom_prompt_block} ${currentBlock!.content}`);
+     
+    await logseq.Editor.updateBlock(customPromptBlock!.uuid, `${customPrompt}`)
+  } catch (e: any) {
+    logseq.App.showMsg(e.toString(), 'warning')
+    console.error(e)
+  }
+}
+
 
 async function getOllamaParametersFromBlockProperties(b: BlockEntity) {
   const properties = await logseq.Editor.getBlockProperties(b.uuid);

--- a/src/ollama.tsx
+++ b/src/ollama.tsx
@@ -186,23 +186,6 @@ export async function summarizeBlock() {
   }
 }
 
-export async function customPromptBlock() {
-  try {
-    if (!logseq.settings) {
-      throw new Error("Couldn't find ollama-logseq settings")
-    }
-  
-    // TODO: Get contnet of current block and subblocks
-    const currentBlock = await logseq.Editor.getCurrentBlock()
-    let customPromptBlock = await logseq.Editor.insertBlock(currentBlock!.uuid, `⌛Apply custom prompt...`, { before: false })
-    const customPrompt = await promptLLM(`${logseq.settings.custom_prompt_block} ${currentBlock!.content}`);
-     
-    await logseq.Editor.updateBlock(customPromptBlock!.uuid, `${customPrompt}`)
-  } catch (e: any) {
-    logseq.App.showMsg(e.toString(), 'warning')
-    console.error(e)
-  }
-}
 
 
 async function getOllamaParametersFromBlockProperties(b: BlockEntity) {


### PR DESCRIPTION
This commit introduces the capability for users to apply custom prompts defined in the configuration to a block. Key changes include:
- A new configuration string to store the custom prompt.
- A menu item 'Custom prompt on block'.
- Implementation of a function to apply the custom prompt to a block, mirroring the existing 'summarize block' functionality.

Sorry I should have open an issue to discuss the feature, I will understand if you refuse it, if so let me know what I should do.

The goal of the PR is to allow the user to define a custom prompt that he uses frequently. In my use case, I often request ollama to reformulate a block to improve clarity and conciseness (not being a english native). By having the prompt defined in configuration and triggered by the menu, it allows to be more convenient and quicker to use. 