### PR TITLE
Improve prompt for card generation

### DIFF
--- a/src/ollama.tsx
+++ b/src/ollama.tsx
@@ -279,7 +279,7 @@ export async function convertToFlashCard(uuid: string, blockContent: string) {
   try {
     const questionBlock = await logseq.Editor.insertBlock(uuid, "⌛Genearting question....", { before: false })
     const answerBlock = await logseq.Editor.insertBlock(questionBlock!.uuid, "⌛Genearting answer....", { before: false })
-    const question = await promptLLM(`Create a question about this that would fit in a flashcard:\n ${blockContent}`)
+    const question = await promptLLM(`Create a question for a flashcard. Provide the question only. Here is the knowledge to check:\n ${blockContent}`)
     const answer = await promptLLM(`Given the question ${question} and the context of ${blockContent} What is the answer? be as brief as possible and provide the answer only.`)
     await logseq.Editor.updateBlock(questionBlock!.uuid, `${question} #card`)
     await delay(300)


### PR DESCRIPTION
Previously, generated cards with llama3 model were broken, because
llama3 was too chatty and provided front and back sides when asked for a
question. Update the prompt to make generation correct.

Before:
![Screenshot_20240510_093032](https://github.com/omagdy7/ollama-logseq/assets/3449635/c7e0ed37-be04-4986-96f5-7b51fd08af65)


After:

![Screenshot_20240510_094503](https://github.com/omagdy7/ollama-logseq/assets/3449635/3c4f2d6c-3ba5-449a-bd91-6404cdf57fac)
