### PR TITLE
feat: add authorization header support, remove protocol from host

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -43,6 +43,13 @@ let settings: SettingSchemaDesc[] = [
     description: "Define your custom prompt and use a block as context",
     default: "Translate in French : "
   },
+  {
+    key: "authorization_header",
+    type: "string",
+    title: "Authorization header",
+    description: "Set the authorization header if your ollama server requires it",
+    default: ""
+  }
 ]
 
 

--- a/src/ollama.tsx
+++ b/src/ollama.tsx
@@ -85,11 +85,16 @@ async function ollamaGenerate(prompt: string, parameters?: OllamaGenerateParamet
   params.stream = false
 
   try {
-    const response = await fetch(`http://${logseq.settings.host}/api/generate`, {
+    let headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+    }
+    if (logseq.settings.authorization_header && logseq.settings.authorization_header.trim() !== "") {
+      headers['Authorization'] = logseq.settings.authorization_header.trim()
+    }
+
+    const response = await fetch(`${logseq.settings.host}/api/generate`, {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
+      headers: headers,
       body: JSON.stringify(params)
     })
     if (!response.ok) {
@@ -105,15 +110,21 @@ async function ollamaGenerate(prompt: string, parameters?: OllamaGenerateParamet
 }
 
 async function promptLLM(prompt: string) {
+  logseq.Editor.exitEditingMode() // Important so the block is identifiable
   if (!logseq.settings) {
     throw new Error("Couldn't find logseq settings");
   }
   try {
-    const response = await fetch(`http://${logseq.settings.host}/api/generate`, {
+    let headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+    }
+    if (logseq.settings.authorization_header && logseq.settings.authorization_header.trim() !== "") {
+      headers['Authorization'] = logseq.settings.authorization_header.trim()
+    }
+
+    const response = await fetch(`${logseq.settings.host}/api/generate`, {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
+      headers: headers,
       body: JSON.stringify({
         model: logseq.settings.model,
         prompt: prompt,


### PR DESCRIPTION
Required for setups where ollama is only accessible through open-webui. I also experienced the block failing to update while it's still selected for editing, perhaps this is only occurs in the DB version of logseq. I don't see why the users should not be able to configure the used API protocol themselves. Let me know what you think :)